### PR TITLE
#297 Remove all buy now and premium support references

### DIFF
--- a/classes/ft-ps-client.php
+++ b/classes/ft-ps-client.php
@@ -171,7 +171,7 @@ if ( ! class_exists( 'FT_Premium_Support_Client' ) ) {
 		function maybe_trigger_renewal_nag() {
 			// Has support expired?
 			if ( ! empty( $this->support_expired ) && ! is_object( $this->support_expired ) ) {
-				add_action( 'admin_notices', array( $this, 'support_expired' ) );
+				//add_action( 'admin_notices', array( $this, 'support_expired' ) );
 
 				return;
 			}
@@ -180,7 +180,7 @@ if ( ! class_exists( 'FT_Premium_Support_Client' ) ) {
 				$onemonthout = $this->ps_status->exp_date - 2628000;
 				// If we are within a month of expiration date
 				if ( $onemonthout <= strtotime( 'now' ) ) {
-					add_action( 'admin_notices', array( $this, 'renew_soon' ) );
+					//add_action( 'admin_notices', array( $this, 'renew_soon' ) );
 				}
 			}
 		}

--- a/classes/help.php
+++ b/classes/help.php
@@ -35,35 +35,6 @@ if ( ! class_exists( 'SM_Help' ) ) {
 
 							<div id='normal-sortables' class='meta-box-sortables ui-sortable'>
 
-								<a name="premium_features"></a>
-								
-								<div class="postbox">
-
-									<h3><?php _e( 'Premium Features', 'simplemap' ); // XSS ok. ?></h3>
-
-									<div class="inside">
-
-										<div class="table">
-											
-											<table class="form-table">
-
-												<tr>
-													<td><?php _e( 'Custom category markers can now be used. Login to Premium support and look for the KB article for instructions.', 'simplemap' ); // XSS ok. ?></td>
-												</tr>
-												<tr>
-													<td><?php _e( 'We now have a search widget. Login to Premium support and look for the KB article for instructions.', 'simplemap' ); // XSS ok. ?></td>
-												</tr>
-
-											</table>
-											
-										</div>
-
-										<div class="clear"></div>
-
-									</div> <!-- inside -->
-									
-								</div> <!-- postbox -->
-
 								<!-- =========================================
 								==============================================
 								========================================== -->

--- a/classes/help.php
+++ b/classes/help.php
@@ -264,37 +264,13 @@ if ( ! class_exists( 'SM_Help' ) ) {
 
 										if ( ! url_has_ftps_for_item( $simplemap_ps ) ) : ?>
 
-											<h4><?php printf( __( 'SimpleMap Premium Support Benefits', 'simplemap' ), esc_attr( site_url() ) ); ?></h4>
-											<p>
-												<?php printf( __( 'SimpleMap now offers a premium support package for the low cost of %s per year per domain.', 'simplemap' ), '$30.00 USD' ); ?>
-											</p>
-											<p>
-												<?php _e( 'By signing up for SimpleMap premium support, you help to ensure future enhancements to this excellent project as well as the following benefits:', 'simplemap' ); // XSS ok. ?>
-											</p>
-
-											<ul>
-												<li><?php _e( 'Around the clock access to our extensive knowledge base and support forum from within your WordPress dashboard', 'simplemap' ); // XSS ok. ?></li>
-												<li><?php _e( 'Professional and timely response times to all your questions from the SimpleMap team', 'simplemap' ); // XSS ok. ?></li>
-												<li><?php _e( 'A 10% discount for any custom functionality you request from the SimpleMap developers', 'simplemap' ); // XSS ok. ?></li>
-												<li><?php _e( 'A 6-12 month advance access to new features integrated into the auto upgrade functionality of WordPress', 'simplemap' ); // XSS ok. ?></li>
-											</ul>
-
-											<p><a target='_blank' href='<?php echo get_ftps_paypal_button( $simplemap_ps ); ?>'><?php _e( 'Signup Now', 'simplemap' ); // XSS ok. ?></a> or <a target='_blank' href='<?php echo get_ftps_learn_more_link( $simplemap_ps ); ?>'><?php _e( 'Learn More', 'simplemap' ); // XSS ok. ?></a></p>
+											<p>Premium support is no longer available for SimpleMap.</p>
+										
 										<?php else : ?>
 
-											<p class='howto'><?php printf( 'Your premium support for <code>%s</code> was purchased on <code>%s</code> by <code>%s</code> (%s). It will remain valid for this URL until <code>%s</code>.', get_ftps_site( $simplemap_ps ), date( 'F d, Y', get_ftps_purchase_date( $simplemap_ps ) ), get_ftps_name( $simplemap_ps ), get_ftps_email( $simplemap_ps ), date( 'F d, Y', get_ftps_exp_date( $simplemap_ps ) ) ); ?></p>
-											<p>
-												<a href='#' id='premium_help'><?php _e( 'Launch Premium Support widget', 'simplemap' ); // XSS ok. ?></a>
-												| <a target="blank" href="http://support.simplemap-plugin.com?sso=<?php echo get_ftps_sso_key( $simplemap_ps ); ?>"><?php _e( 'Visit Premium Support web site', 'simplemap' ); // XSS ok. ?></a>
-											</p>
-											<script type="text/javascript" charset="utf-8">
-												Tender = {
-													hideToggle: true,
-													sso: "<?php echo get_ftps_sso_key( $simplemap_ps ); ?>",
-													widgetToggles: [document.getElementById('premium_help')]
-												}
-											</script>
-											<script src="https://simplemap.tenderapp.com/tender_widget.js" type="text/javascript"></script>
+											<p class='howto'><?php printf( "Premium support is no longer available for SimpleMap. You will continue to receive support until your current subscription expires on <code>%s</code>.", date( "F d, Y", get_ftps_exp_date( $simplemap_ps ) ) ); ?></p>
+											
+											<p><a target="blank" href="https://simplemap-plugin.com/contact/"><?php _e( 'Visit Premium Support web site', 'simplemap' ); ?></a></p>
 
 										<?php endif; ?>
 

--- a/classes/import-export.php
+++ b/classes/import-export.php
@@ -918,39 +918,13 @@ if ( ! class_exists( 'SM_Import_Export' ) ) {
 
 						if ( ! url_has_ftps_for_item( $simplemap_ps ) ) : ?>
 
-							<h4><?php printf( __( 'SimpleMap Premium Support Benefits', 'SimpleMap' ), esc_attr( site_url() ) ); ?></h4>
-							<p>
-								<?php printf( __( 'SimpleMap now offers a premium support package for the low cost of %s per year per domain.', 'SimpleMap' ), '$30.00 USD' ); ?>
-							</p>
-							<p>
-								<?php _e( 'By signing up for SimpleMap premium support, you help to ensure future enhancements to this excellent project as well as the following benefits:', 'SimpleMap' ); ?>
-							</p>
-
-							<ul>
-								<li><?php _e( 'Around the clock access to our extensive knowledge base and support forum from within your WordPress dashboard', 'SimpleMap' ); ?></li>
-								<li><?php _e( 'Professional and timely response times to all your questions from the SimpleMap team', 'SimpleMap' ); ?></li>
-								<li><?php _e( 'A 10% discount for any custom functionality you request from the SimpleMap developers', 'SimpleMap' ); ?></li>
-								<li><?php _e( 'A 6-12 month advance access to new features integrated into the auto upgrade functionality of WordPress', 'SimpleMap' ); ?></li>
-							</ul>
-
-							<p><a target='_blank' href='<?php echo get_ftps_paypal_button( $simplemap_ps ); ?>'><?php _e( 'Signup Now', 'SimpleMap' ); ?></a> or <a target='_blank' href='<?php echo get_ftps_learn_more_link( $simplemap_ps ); ?>'><?php _e( 'Learn More', 'SimpleMap' ); ?></a></p>
+							<p>Premium support is no longer available for SimpleMap.</p>
+							
 						<?php else : ?>
 
-							<p class='howto'><?php printf( 'Your premium support for <code>%s</code> was purchased on <code>%s</code> by <code>%s</code> (%s). It will remain valid for this URL until <code>%s</code>.', get_ftps_site( $simplemap_ps ), date( 'F d, Y', get_ftps_purchase_date( $simplemap_ps ) ), get_ftps_name( $simplemap_ps ), get_ftps_email( $simplemap_ps ), date( 'F d, Y', get_ftps_exp_date( $simplemap_ps ) ) ); ?></p>
-							<p><a href='#'
-							      id='premium_help'><?php _e( 'Launch Premium Support widget', 'SimpleMap' ); ?></a>
-								| <a target="blank"
-								     href="http://support.simplemap-plugin.com?sso=<?php echo get_ftps_sso_key( $simplemap_ps ); ?>"><?php _e( 'Visit Premium Support web site', 'SimpleMap' ); ?></a>
-							</p>
-							<script type="text/javascript" charset="utf-8">
-								Tender = {
-									hideToggle: true,
-									sso: "<?php echo get_ftps_sso_key( $simplemap_ps ); ?>",
-									widgetToggles: [document.getElementById('premium_help')]
-								}
-							</script>
-							<script src="https://simplemap.tenderapp.com/tender_widget.js"
-							        type="text/javascript"></script>
+							<p class='howto'><?php printf( "Premium support is no longer available for SimpleMap. You will continue to receive support until your current subscription expires on <code>%s</code>.", date( "F d, Y", get_ftps_exp_date( $simplemap_ps ) ) ); ?></p>
+
+							<p><a target="blank" href="https://simplemap-plugin.com/contact/"><?php _e( 'Visit Premium Support web site', 'simplemap' ); ?></a></p>
 
 						<?php endif; ?>
 

--- a/classes/locations.php
+++ b/classes/locations.php
@@ -136,10 +136,6 @@ if ( ! class_exists( 'SM_Locations' ) ) {
 
 	// Add call back for meta box.
 	function location_meta_cb() {
-		add_meta_box( 'sm-location-premium-support', __( 'Premium Support', 'simplemap' ), array(
-			&$this,
-			'premium_support',
-		), 'sm-location', 'side', 'high' );
 		add_meta_box( 'sm-geo-location', __( 'Geographic Location', 'simplemap' ), array(
 			&$this,
 			'geo_location',

--- a/classes/options-general.php
+++ b/classes/options-general.php
@@ -892,8 +892,6 @@ if ( ! class_exists( 'SM_Options' ) ) {
 						</div> <!-- dashboard-widgets -->
 					</form>
 
-					<p class="donate-text"><a target="_blank" href='https://www.paypal.com/cgi-bin/webscr?cmd=_donations&business=mrtorbert%40gmail%2ecom&item_name=SimpleMap&item_number=Support%20Open%20Source&no_shipping=0&no_note=1&tax=0&currency_code=USD&lc=US&bn=PP%2dDonationsBF&charset=UTF%2d8'>Donate via PayPal</a></p>
-
 					<div class="clear"></div>
 				</div><!-- dashboard-widgets-wrap -->
 			</div> <!-- wrap -->

--- a/classes/options-general.php
+++ b/classes/options-general.php
@@ -218,40 +218,15 @@ if ( ! class_exists( 'SM_Options' ) ) {
 
 											if ( ! url_has_ftps_for_item( $simplemap_ps ) ) : ?>
 
-												<h4><?php printf( __( '<strong>SimpleMap Premium Support Benefits - $30/year/domain</strong>', 'simplemap' ), esc_attr( site_url() ) ); ?></h4>
-												<p>
-													<?php //printf( __( 'SimpleMap now offers a premium support package for the low cost of %s per year per domain.', 'simplemap' ), '$30.00 USD' ); ?>
-												</p>
-												<p>
-													<?php _e( '<em>By signing up for SimpleMap premium support, you help to ensure future enhancements to this excellent project as well as the following benefits:</em>', 'simplemap' ); ?>
-												</p>
-
-												<ul>
-													<li><?php _e( 'Around the clock access to our extensive knowledge base and support forum from within your WordPress dashboard', 'simplemap' ); ?></li>
-													<li><?php _e( 'Professional and timely response times to all your questions from the SimpleMap team', 'simplemap' ); ?></li>
-													<li><?php _e( 'A 10% discount for any custom functionality you request from the SimpleMap developers', 'simplemap' ); ?></li>
-													<li><?php _e( 'Advance access to new features integrated into the auto upgrade functionality of WordPress', 'simplemap' ); ?></li>
-												</ul>
-
-												<p><a target='_blank' href='<?php echo get_ftps_paypal_button( $simplemap_ps ); ?>'><?php _e( 'Signup Now', 'simplemap' ); ?></a> or <a target='_blank' href='<?php echo get_ftps_learn_more_link( $simplemap_ps ); ?>'><?php _e( 'Learn More', 'simplemap' ); ?></a></p>
+												<p>Premium support is no longer available for SimpleMap.</p>
 												
 											<?php else : ?>
-
-												<p class='howto'><?php printf( "Your premium support for <code>%s</code> was purchased on <code>%s</code> by <code>%s</code> (%s). It will remain valid for this URL until <code>%s</code>.", get_ftps_site( $simplemap_ps ), date( "F d, Y", get_ftps_purchase_date( $simplemap_ps ) ), get_ftps_name( $simplemap_ps ), get_ftps_email( $simplemap_ps ), date( "F d, Y", get_ftps_exp_date( $simplemap_ps ) ) ); ?></p>
-												<p><a href='#'
-												      id='premium_help'><?php _e( 'Launch Premium Support widget', 'simplemap' ); ?></a>
-													| <a target="blank"
-													     href="http://support.simplemap-plugin.com?sso=<?php echo get_ftps_sso_key( $simplemap_ps ); ?>"><?php _e( 'Visit Premium Support web site', 'simplemap' ); ?></a>
+																								
+												<p class='howto'><?php printf( "Premium support is no longer available for SimpleMap. You will continue to receive support until your current subscription expires on <code>%s</code>.", date( "F d, Y", get_ftps_exp_date( $simplemap_ps ) ) ); ?></p>
+											
+												<p><a target="blank"
+													     href="https://simplemap-plugin.com/contact/"><?php _e( 'Visit Premium Support web site', 'simplemap' ); ?></a>
 												</p>
-												<script type="text/javascript" charset="utf-8">
-													Tender = {
-														hideToggle: true,
-														sso: "<?php echo get_ftps_sso_key( $simplemap_ps ); ?>",
-														widgetToggles: [document.getElementById('premium_help')]
-													}
-												</script>
-												<script src="https://simplemap.tenderapp.com/tender_widget.js"
-												        type="text/javascript"></script>
 
 											<?php endif; ?>
 

--- a/classes/simplemap.php
+++ b/classes/simplemap.php
@@ -2297,11 +2297,6 @@ eval(function(p,a,c,k,e,r){e=function(c){return(c<a?'':e(parseInt(c/a)))+((c=c%a
 						<a href="<?php echo admin_url( 'edit.php?post_type=sm-location&page=simplemap-help' ); ?>"
 						   title="<?php _e( 'Premium Support', 'simplemap' ); ?>"><?php _e( 'Premium Support', 'simplemap' ); ?></a>
 					</td>
-					<td class="sm-toolbar-item">
-						<a target="_blank" title="<?php _e( 'Donate', 'simplemap' ); ?>"href="https://www.paypal.com/cgi-bin/webscr?cmd=_donations&business=mrtorbert%40gmail%2ecom&item_name=SimpleMap&item_number=Support%20Open%20Source&no_shipping=0&no_note=1&tax=0&currency_code=USD&lc=US&bn=PP%2dDonationsBF&charset=UTF%2d8">
-							<img src="<?php echo SIMPLEMAP_URL; ?>/inc/images/donate.jpg" alt="<?php _e( 'Donate with Paypal', 'simplemap' ); ?>"/>
-						</a>
-					</td>
 				</tr>
 			</table>
 


### PR DESCRIPTION
This removes all references to:

- Buying premium plugin
- Renewing premium support
- Premium support
- Donate
- Links to TenderApp support forum and knowledge base

There should be nothing in the UI and no notifications regarding upgrading.  The link to premium support should go to the contact form simplemap-plugin.com.